### PR TITLE
Change default version to 3.7 because 3.6 is EOL.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ rabbitmq_daemon: rabbitmq-server
 rabbitmq_state: started
 rabbitmq_enabled: true
 
-rabbitmq_version: "3.6.16"
+rabbitmq_version: "3.7.17"
 
 rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el{{ ansible_distribution_major_version }}.noarch.rpm"
 rabbitmq_rpm_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/el/{{ ansible_distribution_major_version }}/{{ rabbitmq_rpm }}/download"


### PR DESCRIPTION
See "3.6.16" on https://www.rabbitmq.com/changelog.html