### PR TITLE
Switched to Package Cloud repositories on RedHat / Centos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,20 @@ Available variables are listed below, along with default values (see `defaults/m
 
 Controls the RabbitMQ daemon's state and whether it starts at boot.
 
-    rabbitmq_version: "3.6.16"
+    rabbitmq_version: "3.8.0"
 
 The RabbitMQ version to install.
 
-    rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el{{ ansible_distribution_major_version }}.noarch.rpm"
-    rabbitmq_rpm_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/el/{{ ansible_distribution_major_version }}/{{ rabbitmq_rpm }}/download"
+    rabbitmq_basename: "rabbitmq-server"
 
-(RedHat/CentOS only) Controls the .rpm to install.
+(RedHat/CentOS only) The RabbitMQ package basename.
+    
+    erlang_yum_repository_url: "https://packagecloud.io/install/repositories/rabbitmq/erlang/config_file.repo?os={{ansible_distribution | lower}}&dist={{ ansible_distribution_major_version }}&source=script"
+    rabbitmq_yum_repository_url: "https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/config_file.repo?os={{ansible_distribution | lower}}&dist={{ansible_distribution_major_version | lower}}&source=script"
+    erlang_yum_repository_path: "/etc/yum.repos.d/rabbitmq_erlang.repo"
+    rabbitmq_yum_repository_path: "/etc/yum.repos.d/rabbitmq_rabbitmq-server.repo"
+
+(RedHat/CentOS only) Controls the Package Cloud repositories for RabbitMQ and Erlang latest versions
 
     rabbitmq_deb: "rabbitmq-server_{{ rabbitmq_version }}-1_all.deb"
     rabbitmq_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/{{ rabbitmq_deb }}/download"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,10 +3,14 @@ rabbitmq_daemon: rabbitmq-server
 rabbitmq_state: started
 rabbitmq_enabled: true
 
-rabbitmq_version: "3.6.16"
-
-rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el{{ ansible_distribution_major_version }}.noarch.rpm"
-rabbitmq_rpm_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/el/{{ ansible_distribution_major_version }}/{{ rabbitmq_rpm }}/download"
+rabbitmq_version: "3.8.0"
+rabbitmq_basename: "rabbitmq-server"
 
 rabbitmq_deb: "rabbitmq-server_{{ rabbitmq_version }}-1_all.deb"
 rabbitmq_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/{{ rabbitmq_deb }}/download"
+
+erlang_yum_repository_url: "https://packagecloud.io/install/repositories/rabbitmq/erlang/config_file.repo?os={{ansible_distribution | lower}}&dist={{ ansible_distribution_major_version }}&source=script"
+rabbitmq_yum_repository_url: "https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/config_file.repo?os={{ansible_distribution | lower}}&dist={{ansible_distribution_major_version | lower}}&source=script"
+
+erlang_yum_repository_path: "/etc/yum.repos.d/rabbitmq_erlang.repo"
+rabbitmq_yum_repository_path: "/etc/yum.repos.d/rabbitmq_rabbitmq-server.repo"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Ensure erlang is installed.
-  package:
-    name: erlang
-    state: present
-
 # Setup/install tasks.
 - include: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,9 @@
 ---
+- name: Ensure erlang is installed.
+  package:
+    name: erlang
+    state: present
+
 - name: Download RabbitMQ package.
   get_url:
     url: "{{ rabbitmq_deb_url }}"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,6 +1,4 @@
 ---
-- debug: var=packagecloud_repository_url
-
 - name: Get packagecloud erlang repository
   get_url:
     url: "{{ erlang_yum_repository_url }}"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,15 +1,28 @@
 ---
+- debug: var=packagecloud_repository_url
+
+- name: Get packagecloud erlang repository
+  get_url:
+    url: "{{ erlang_yum_repository_url }}"
+    dest: "{{ erlang_yum_repository_path }}"
+    force: yes
+
+- name: Get packagecloud rabbitmq repository
+  get_url:
+    url: "{{ rabbitmq_yum_repository_url }}"
+    dest: "{{ rabbitmq_yum_repository_path }}"
+    force: yes
+
 - name: Add packagecloud GPG key.
   rpm_key:
     key: "https://packagecloud.io/gpg.key"
     state: present
 
-- name: Download RabbitMQ package.
-  get_url:
-    url: "{{ rabbitmq_rpm_url }}"
-    dest: "/tmp/{{ rabbitmq_rpm }}"
-
 - name: Ensure RabbitMQ is installed.
   yum:
-    name: "/tmp/{{ rabbitmq_rpm }}"
+    name: "{{rabbitmq_basename}}-{{rabbitmq_version}}"
     state: "present"
+    disablerepo: "epel"
+    enablerepo:
+     - rabbitmq_erlang
+     - rabbitmq_rabbitmq-server


### PR DESCRIPTION
Hi,

Since epel doesn't have the latest versions of Erlang I've changed the RedHat / Centos tasks to use the Package Cloud repositories so the role is able to install both Erlang and RabbitMQ on the latest versions.
Also switched the default version to 3.8.0 (the current latest version available).