### PR TITLE
Add new GPG key

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,8 +1,11 @@
 ---
 - name: Add packagecloud GPG key.
   rpm_key:
-    key: "https://packagecloud.io/gpg.key"
+    key: "{{ item }}"
     state: present
+  loop:
+    - "https://packagecloud.io/gpg.key"
+    - "https://www.rabbitmq.com/rabbitmq-release-signing-key.asc"
 
 - name: Download RabbitMQ package.
   get_url:


### PR DESCRIPTION
Cause existed fail to validate rpm
```
FAILED! => {"changed": false, "msg": "Failed to validate GPG signature for rabbitmq-server-3.8.4-1.el8.noarch"}
```
In docs for rpm installation, I found new keys, but only this work for version 3.8.4
https://www.rabbitmq.com/install-rpm.html