### PR TITLE
Update minimum version of rabbitMQ

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ rabbitmq_daemon: rabbitmq-server
 rabbitmq_state: started
 rabbitmq_enabled: true
 
-rabbitmq_version: "3.6.16"
+rabbitmq_version: "3.7.18"
 
 rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el{{ ansible_distribution_major_version }}.noarch.rpm"
 rabbitmq_rpm_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/el/{{ ansible_distribution_major_version }}/{{ rabbitmq_rpm }}/download"


### PR DESCRIPTION
Hey,

Thanks for this package.
It seems that packagecloud does not host 3.6.16 version anymore.
https://packagecloud.io/rabbitmq/rabbitmq-server/packages/debian/buster/rabbitmq-server_3.6.16-1_all.deb/download result in a 404
https://packagecloud.io/rabbitmq/rabbitmq-server/packages/debian/buster/rabbitmq-server_3.7.18-1_all.deb/download is OK

The minimum version is now 3.7.18.

Hope this can help someone,