### PR TITLE
Update setup-RedHat.yml

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,8 +1,13 @@
 ---
-- name: Add packagecloud GPG key.
+- name: Add GPG keys.
   rpm_key:
-    key: "https://packagecloud.io/gpg.key"
+    key: "{{ item }}"
     state: present
+  with_items:
+    - "https://packagecloud.io/gpg.key"
+    - "https://packagecloud.io/rabbitmq/erlang/gpgkey"
+    - "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey"
+    - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc"
 
 - name: Download RabbitMQ package.
   get_url:


### PR DESCRIPTION
```
TASK [geerlingguy.rabbitmq : Ensure RabbitMQ is installed.] ********************
fatal: [rmq1]: FAILED! => {"changed": false, "msg": "Failed to validate GPG signature for rabbitmq-server-3.8.3-1.el8.noarch"}
```
Perhaps missing all the gpg keys?

https://github.com/rabbitmq/rabbitmq-website/blob/live/site/install-rpm.md#package-cloud