### PR TITLE
Ensure legacy crypto policies for RHEL > 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
     strategy:
       matrix:
         distro:
+          - rockylinux9
           - rockylinux8
           - centos7
           - ubuntu2004

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -4,6 +4,11 @@
     name: erlang
     state: present
 
+- name: Get current crypto policy
+  command: update-crypto-policies --show
+  register: current_crypto_policy
+  changed_when: false
+
 - name: Ensure legacy crypto policies
   command: update-crypto-policies --set LEGACY
   when: ansible_distribution_major_version | int > 8
@@ -19,7 +24,7 @@
     - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc"
 
 - name: Rollback legacy crypto policies
-  command: update-crypto-policies --set DEFAULT
+  command: update-crypto-policies --set "{{ current_crypto_policy.stdout }}"
   when: ansible_distribution_major_version | int > 8
 
 - name: Download RabbitMQ package.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -4,6 +4,10 @@
     name: erlang
     state: present
 
+- name: Ensure legacy crypto policies
+  command: update-crypto-policies --set LEGACY
+  when: ansible_distribution_major_version | int > 8
+
 - name: Add GPG keys.
   rpm_key:
     key: "{{ item }}"
@@ -13,6 +17,10 @@
     - "https://packagecloud.io/rabbitmq/erlang/gpgkey"
     - "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey"
     - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc"
+
+- name: Rollback legacy crypto policies
+  command: update-crypto-policies --set DEFAULT
+  when: ansible_distribution_major_version | int > 8
 
 - name: Download RabbitMQ package.
   get_url:


### PR DESCRIPTION
Running this role on a fresh Rocky9 machine fails returning a Hash algorithm SHA1 not available error. I guess the error is caused by the SHA1 deprecation on RHEL9 https://www.redhat.com/en/blog/rhel-security-sha-1-package-signatures-distrusted-rhel-9. 

The official rabbitmq docs https://www.rabbitmq.com/install-rpm.html#package-cloud state, that:

> Note that if any of the above import commands finishes with an error due to the SHA1 hash algorithm, you must execute the following first:
> ```sudo update-crypto-policies --set LEGACY```
> And then retry the failed import command(s).

I was able to workaround this issue by applying the proposed changes.

On the other hand, maybe the crypto policies strategy should be recorded beforehand and changed only if it's not in LAGACY mode? Otherwise this might accidentally change someone's LEGACY setting to DEFAULT?  What do you thing @geerlingguy 