### PR TITLE
No more packagecloud repository working, no erlang versions installed correctly in latest rabbit versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ The RabbitMQ version to install.
 
 (RedHat/CentOS only) Controls the .rpm to install.
 
-    rabbitmq_deb: "rabbitmq-server_{{ rabbitmq_version }}-1_all.deb"
-    rabbitmq_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/{{ rabbitmq_deb }}/download"
+    rabbitmq_apt_repository: "deb [signed-by=/etc/apt/trusted.gpg.d/rabbitmq-9F4587F226208342.gpg] https://ppa1.novemberain.com/rabbitmq/rabbitmq-server/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
+    rabbitmq_apt_gpg_url: "https://ppa.novemberain.com/gpg.9F4587F226208342.key"
 
-(Debian/Ubuntu only) Controls the .deb to install.
+    erlang_apt_repository: "deb [signed-by=/etc/apt/trusted.gpg.d/erlang-E495BB49CC4BBE5B.gpg] https://ppa2.novemberain.com/rabbitmq/rabbitmq-erlang/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
+    erlang_apt_gpg_url: "https://ppa.novemberain.com/gpg.E495BB49CC4BBE5B.key"
+(Debian/Ubuntu only) Controls the repository configuration for the installation
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,10 +3,13 @@ rabbitmq_daemon: rabbitmq-server
 rabbitmq_state: started
 rabbitmq_enabled: true
 
-rabbitmq_version: "3.9.13"
+rabbitmq_version: "3.12.2"
 
 rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el{{ ansible_distribution_major_version }}.noarch.rpm"
 rabbitmq_rpm_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/el/{{ ansible_distribution_major_version }}/{{ rabbitmq_rpm }}/download"
 
-rabbitmq_deb: "rabbitmq-server_{{ rabbitmq_version }}-1_all.deb"
-rabbitmq_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/{{ rabbitmq_deb }}/download"
+rabbitmq_apt_repository: "deb [signed-by=/etc/apt/trusted.gpg.d/rabbitmq-9F4587F226208342.gpg] https://ppa1.novemberain.com/rabbitmq/rabbitmq-server/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
+rabbitmq_apt_gpg_url: "https://ppa.novemberain.com/gpg.9F4587F226208342.key"
+
+erlang_apt_repository: "deb [signed-by=/etc/apt/trusted.gpg.d/erlang-E495BB49CC4BBE5B.gpg] https://ppa2.novemberain.com/rabbitmq/rabbitmq-erlang/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
+erlang_apt_gpg_url: "https://ppa.novemberain.com/gpg.E495BB49CC4BBE5B.key"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -11,17 +11,38 @@
     - ansible_distribution == 'Ubuntu'
     - ansible_distribution_major_version | int >= 18
 
+- name: Download gpg keys and erlang repository
+  block:
+    - name: Download gpg keys for erlang repository updated
+      ansible.builtin.apt_key:
+        id: E495BB49CC4BBE5B
+        url: "{{ erlang_apt_gpg_url }}"
+        keyring: /etc/apt/trusted.gpg.d/erlang-E495BB49CC4BBE5B.gpg
+
+    - name: Ensure erlang updated repository is configured
+      ansible.builtin.apt_repository:
+        repo: "{{ erlang_apt_repository }}"
+        state: present
+
+- name: Add rabbitmq apt and keys and repository
+  block:
+    - name: Download gpg keys for rabbitmq-server repository
+      ansible.builtin.apt_key:
+        id: 9F4587F226208342
+        url: "{{ rabbitmq_apt_gpg_url }}"
+        keyring: /etc/apt/trusted.gpg.d/rabbitmq-9F4587F226208342.gpg
+
+    - name: Ensure rabbitmq-server repository is configured
+      ansible.builtin.apt_repository:
+        repo: "{{ rabbitmq_apt_repository }}"
+        state: present
+
 - name: Ensure erlang is installed.
   package:
     name: erlang
     state: present
 
-- name: Download RabbitMQ package.
-  get_url:
-    url: "{{ rabbitmq_deb_url }}"
-    dest: "/tmp/{{ rabbitmq_deb }}"
-
 - name: Ensure RabbitMQ is installed.
   apt:
-    deb: "/tmp/{{ rabbitmq_deb }}"
+    name: rabbitmq-server={{ rabbitmq_version }}-1
     state: present


### PR DESCRIPTION
just that :) i updated the script because is not working for me and i doit this, tested in Ubuntu 22.04.3

based in that installation documentation: https://www.rabbitmq.com/install-debian.html#apt-cloudsmith

- > installation from apt method not from .deb file with gpg keys
- > updated to the new repository
- > adapted default variables for sources.list format
- > add erlang repository to get newer versions required for the package
- > updated README.md with new variables for debian