### PR TITLE
Fix apt gpg keys and erlang version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ rabbitmq_enabled: true
 Controls the RabbitMQ daemon's state and whether it starts at boot.
 
 ```yaml
-rabbitmq_version: "3.9.13"
+rabbitmq_version: "3.12.2"
 ```
 
 The RabbitMQ version to install.
@@ -34,11 +34,11 @@ rabbitmq_rpm_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/el/
 (RedHat/CentOS only) Controls the .rpm to install.
 
 ```yaml
-rabbitmq_apt_repository: "deb [signed-by=/etc/apt/trusted.gpg.d/rabbitmq-9F4587F226208342.gpg] https://ppa1.novemberain.com/rabbitmq/rabbitmq-server/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
-rabbitmq_apt_gpg_url: "https://ppa.novemberain.com/gpg.9F4587F226208342.key"
+rabbitmq_apt_repository: "https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/{{ ansible_distribution | lower }}"
+rabbitmq_apt_gpg_url: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key"
 
-erlang_apt_repository: "deb [signed-by=/etc/apt/trusted.gpg.d/erlang-E495BB49CC4BBE5B.gpg] https://ppa2.novemberain.com/rabbitmq/rabbitmq-erlang/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
-erlang_apt_gpg_url: "https://ppa.novemberain.com/gpg.E495BB49CC4BBE5B.key"
+erlang_apt_repository: "https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/{{ ansible_distribution | lower }}"
+erlang_apt_gpg_url: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key"
 ```
 
 (Debian/Ubuntu only) Controls the repository configuration for the installation

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,8 +8,8 @@ rabbitmq_version: "3.12.2"
 rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el{{ ansible_distribution_major_version }}.noarch.rpm"
 rabbitmq_rpm_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/el/{{ ansible_distribution_major_version }}/{{ rabbitmq_rpm }}/download"
 
-rabbitmq_apt_repository: "deb [signed-by=/etc/apt/trusted.gpg.d/rabbitmq-9F4587F226208342.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
+rabbitmq_apt_repository: "https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/{{ ansible_distribution | lower }}"
 rabbitmq_apt_gpg_url: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key"
 
-erlang_apt_repository: "deb [signed-by=/etc/apt/trusted.gpg.d/erlang-E495BB49CC4BBE5B.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
+erlang_apt_repository: "https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/{{ ansible_distribution | lower }}"
 erlang_apt_gpg_url: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,5 +8,10 @@
       apt: update_cache=true cache_valid_time=600
       when: ansible_os_family == 'Debian'
 
+    - name: Add python3-debian
+      when: ansible_os_family == 'Debian'
+      apt:
+        name: [python3-debian]
+
   roles:
     - role: geerlingguy.rabbitmq

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -15,22 +15,18 @@
   ansible.builtin.deb822_repository:
     components: main
     name: erlang
-    signed_by: https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key
-    suites: '{{ ansible_distribution_release }}'
-    uris:
-      - https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu
-      - https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu
+    signed_by: "{{ erlang_apt_gpg_url }}"
+    suites: "{{ ansible_distribution_release }}"
+    uris: ["{{ erlang_apt_repository }}"]
     types: deb
 
 - name: Add RabbitMQ repository
   ansible.builtin.deb822_repository:
     components: main
     name: rabbitmq
-    signed_by: https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key
-    suites: '{{ ansible_distribution_release }}'
-    uris:
-      - https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu
-      - https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu
+    signed_by: "{{ rabbitmq_apt_gpg_url }}"
+    suites: "{{ ansible_distribution_release }}"
+    uris: ["{{ rabbitmq_apt_repository }}"]
     types: deb
 
 # https://www.rabbitmq.com/docs/which-erlang

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -11,18 +11,27 @@
     - ansible_distribution == 'Ubuntu'
     - ansible_distribution_major_version | int >= 18
 
-- name: Download gpg keys and erlang repository
-  block:
-    - name: Download gpg keys for erlang repository updated
-      ansible.builtin.apt_key:
-        id: E495BB49CC4BBE5B
-        url: "{{ erlang_apt_gpg_url }}"
-        keyring: /etc/apt/trusted.gpg.d/erlang-E495BB49CC4BBE5B.gpg
+- name: Add Erlang repository
+  ansible.builtin.deb822_repository:
+    components: main
+    name: erlang
+    signed_by: https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key
+    suites: '{{ ansible_distribution_release }}'
+    uris:
+      - https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu
+      - https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu
+    types: deb
 
-    - name: Ensure erlang updated repository is configured
-      ansible.builtin.apt_repository:
-        repo: "{{ erlang_apt_repository }}"
-        state: present
+- name: Add RabbitMQ repository
+  ansible.builtin.deb822_repository:
+    components: main
+    name: rabbitmq
+    signed_by: https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key
+    suites: '{{ ansible_distribution_release }}'
+    uris:
+      - https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu
+      - https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu
+    types: deb
 
 - name: Add rabbitmq apt and keys and repository
   block:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -33,18 +33,18 @@
       - https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu
     types: deb
 
-- name: Add rabbitmq apt and keys and repository
-  block:
-    - name: Download gpg keys for rabbitmq-server repository
-      ansible.builtin.apt_key:
-        id: 9F4587F226208342
-        url: "{{ rabbitmq_apt_gpg_url }}"
-        keyring: /etc/apt/trusted.gpg.d/rabbitmq-9F4587F226208342.gpg
+# https://www.rabbitmq.com/docs/which-erlang
+- name: Setup Erlang version pin
+  ansible.builtin.template:
+    src: apt_pin.j2
+    dest: "/etc/apt/preferences.d/erlang"
+    owner: root
+    group: root
+    mode: 0644
 
-    - name: Ensure rabbitmq-server repository is configured
-      ansible.builtin.apt_repository:
-        repo: "{{ rabbitmq_apt_repository }}"
-        state: present
+- name: Update apt cache.
+  apt: update_cache=true
+  when: ansible_os_family == 'Debian'
 
 - name: Ensure erlang is installed.
   ansible.builtin.package:

--- a/templates/apt_pin.j2
+++ b/templates/apt_pin.j2
@@ -1,0 +1,8 @@
+# https://www.rabbitmq.com/docs/which-erlang
+Package: erlang*
+{% if rabbitmq_version is version('3.12.10', '>=') %}
+Pin: version 1:26.2.5.9-1
+{% else %}
+Pin: version 1:25.3.2.18-1
+{% endif %}
+Pin-Priority: 1001


### PR DESCRIPTION
Hi, this PR changes the Debian/Ubuntu logic to fix RabbitMQ/Erlang repo add.

It contains an additional change to ensure a compatible Erlang version is installed:

- https://www.rabbitmq.com/docs/install-debian#apt-pinning
- https://www.rabbitmq.com/docs/which-erlang

Rationale: it was always picking the newest Erlang and failing my local Molecule runs with the default value of `rabbitmq_version`.

The downside is that now you need `python-debian`/`python3-debian` because it is required by `deb822_repository` module:

- https://docs.ansible.com/ansible/latest/collections/ansible/builtin/deb822_repository_module.html#requirements

You can find my CI test matrix example here:

- https://github.com/parcimonic/ansible-role-rabbitmq/actions/runs/13982581188

I've included Ubuntu 24.04 there just in case :shrug: , but you can see that the lowest supported version for it is `3.12.14`. Evidence: my other pipeline run with a lot more versions which failed about 50% of the tasks, because some versions of RabbitMQ are not available in some distros (specially Ubuntu 24.04).

- https://github.com/parcimonic/ansible-role-rabbitmq/actions/runs/13959680028

All changes to the CI workflow file were pushed to my other branch here:

- https://github.com/parcimonic/ansible-role-rabbitmq/blob/ci-branch/.github/workflows/ci.yml 