### PR TITLE
Fix RPM GPG key install

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ rabbitmq_version: "3.9.13"
 The RabbitMQ version to install.
 
 ```yaml
-rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el{{ ansible_distribution_major_version }}.noarch.rpm"
-rabbitmq_rpm_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/el/{{ ansible_distribution_major_version }}/{{ rabbitmq_rpm }}/download"
+rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el8.noarch.rpm"
+rabbitmq_rpm_url: "https://github.com/rabbitmq/rabbitmq-server/releases/download/v{{ rabbitmq_version }}/{{ rabbitmq_rpm }}"
+rabbitmq_rpm_gpg_url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
 ```
 
 (RedHat/CentOS only) Controls the .rpm to install.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,8 +5,9 @@ rabbitmq_enabled: true
 
 rabbitmq_version: "3.12.2"
 
-rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el{{ ansible_distribution_major_version }}.noarch.rpm"
-rabbitmq_rpm_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/el/{{ ansible_distribution_major_version }}/{{ rabbitmq_rpm }}/download"
+rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el8.noarch.rpm"
+rabbitmq_rpm_url: "https://github.com/rabbitmq/rabbitmq-server/releases/download/v{{ rabbitmq_version }}/{{ rabbitmq_rpm }}"
+rabbitmq_rpm_gpg_url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
 
 rabbitmq_apt_repository: "deb [signed-by=/etc/apt/trusted.gpg.d/rabbitmq-9F4587F226208342.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
 rabbitmq_apt_gpg_url: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -6,12 +6,8 @@
 
 - name: Add GPG keys.
   rpm_key:
-    key: "{{ item }}"
+    key: "{{ rabbitmq_rpm_gpg_url }}"
     state: present
-  with_items:
-    - "https://packagecloud.io/rabbitmq/erlang/gpgkey"
-    - "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey"
-    - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc"
 
 - name: Download RabbitMQ package.
   get_url:


### PR DESCRIPTION
Hi, this PR brings changes to the RPM GPG key handling. Based on the document here:

- https://www.rabbitmq.com/docs/install-rpm#downloads

CI results and workflow file:

- https://github.com/parcimonic/ansible-role-rabbitmq/actions/runs/13997785619
- https://github.com/parcimonic/ansible-role-rabbitmq/blob/ci-branch-rpm/.github/workflows/ci.yml

RabbitMQ 3.11 failed to install because it needs older Erlang:

- https://www.rabbitmq.com/docs/which-erlang

It can be fixed by using repo pinning, like done with APT (PR #27), but since this version is already [out of support](https://www.rabbitmq.com/release-information) I decided to not touch it.