### PR TITLE
Switch Debian repos to deb1 + scoped keyring

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,16 @@ rabbitmq_rpm_gpg_url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
 (RedHat/CentOS only) Controls the .rpm to install.
 
 ```yaml
-rabbitmq_apt_repository: "https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/{{ ansible_facts.distribution | lower }}"
-rabbitmq_apt_gpg_url: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key"
-
-erlang_apt_repository: "https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/{{ ansible_facts.distribution | lower }}"
-erlang_apt_gpg_url: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key"
+rabbitmq_apt_repository: "https://deb1.rabbitmq.com/rabbitmq-server/{{ ansible_facts.distribution | lower }}/{{ ansible_facts.distribution_release }}"
+erlang_apt_repository: "https://deb1.rabbitmq.com/rabbitmq-erlang/{{ ansible_facts.distribution | lower }}/{{ ansible_facts.distribution_release }}"
+rabbitmq_apt_keyring_path: "/usr/share/keyrings/com.rabbitmq.team.gpg"
+rabbitmq_apt_key_fingerprint: "0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ```
 
-(Debian/Ubuntu only) Controls the repository configuration for the installation
+(Debian/Ubuntu only) Controls the repository configuration for the installation.
+The role uses RabbitMQ's `deb1` mirror plus the Team RabbitMQ signing key by
+default. If `rabbitmq_apt_keyring_path` is unset, the role falls back to the
+legacy `rabbitmq_apt_gpg_url` / `erlang_apt_gpg_url` locations instead.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ rabbitmq_enabled: true
 Controls the RabbitMQ daemon's state and whether it starts at boot.
 
 ```yaml
-rabbitmq_version: "3.12.2"
+rabbitmq_version: "3.12.14"
 ```
 
 The RabbitMQ version to install.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ rabbitmq_daemon: rabbitmq-server
 rabbitmq_state: started
 rabbitmq_enabled: true
 
-rabbitmq_version: "3.12.2"
+rabbitmq_version: "3.12.14"
 
 rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el8.noarch.rpm"
 rabbitmq_rpm_url: "https://github.com/rabbitmq/rabbitmq-server/releases/download/v{{ rabbitmq_version }}/{{ rabbitmq_rpm }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,8 +9,13 @@ rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el8.noarch.rpm"
 rabbitmq_rpm_url: "https://github.com/rabbitmq/rabbitmq-server/releases/download/v{{ rabbitmq_version }}/{{ rabbitmq_rpm }}"
 rabbitmq_rpm_gpg_url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
 
-rabbitmq_apt_repository: "https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/{{ ansible_facts.distribution | lower }}"
-rabbitmq_apt_gpg_url: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key"
+rabbitmq_apt_key_fingerprint: "0A9AF2115F4687BD29803A206B73A36E6026DFCA"
+rabbitmq_apt_key_source: "https://keys.openpgp.org/vks/v1/by-fingerprint/{{ rabbitmq_apt_key_fingerprint }}"
+rabbitmq_apt_keyring_path: "/usr/share/keyrings/com.rabbitmq.team.gpg"
 
-erlang_apt_repository: "https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/{{ ansible_facts.distribution | lower }}"
+rabbitmq_apt_repository: "https://deb1.rabbitmq.com/rabbitmq-server/{{ ansible_facts.distribution | lower }}/{{ ansible_facts.distribution_release }}"
+erlang_apt_repository: "https://deb1.rabbitmq.com/rabbitmq-erlang/{{ ansible_facts.distribution | lower }}/{{ ansible_facts.distribution_release }}"
+
+# Legacy fallback URLs used only when rabbitmq_apt_keyring_path is undefined.
+rabbitmq_apt_gpg_url: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key"
 erlang_apt_gpg_url: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,7 +1,7 @@
 ---
 # See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199 and
 # https://github.com/geerlingguy/ansible-role-java/issues/64
-- name: Ensure 'man' directory exists.
+- name: Ensure 'man' directory exists
   ansible.builtin.file: # noqa risky-file-permissions
     path: /usr/share/man/man1
     state: directory
@@ -11,11 +11,43 @@
     - ansible_facts.distribution == 'Ubuntu'
     - ansible_facts.distribution_major_version | int >= 18
 
+- name: Ensure APT transport and GnuPG are present
+  ansible.builtin.package:
+    name:
+      - curl
+      - gnupg
+      - apt-transport-https
+    state: present
+  when: ansible_facts.os_family == 'Debian'
+
+- name: Ensure RabbitMQ signing key directory exists
+  ansible.builtin.file:
+    path: "{{ rabbitmq_apt_keyring_path | dirname }}"
+    state: directory
+    mode: "0755"
+  when: rabbitmq_apt_keyring_path is defined
+
+- name: Download RabbitMQ APT signing key
+  ansible.builtin.get_url:
+    url: "{{ rabbitmq_apt_key_source | default(rabbitmq_apt_gpg_url) }}"
+    dest: /tmp/rabbitmq-team.asc
+    mode: "0644"
+  register: rabbitmq_apt_key_download
+  when: rabbitmq_apt_keyring_path is defined
+
+- name: Install RabbitMQ APT signing key
+  ansible.builtin.command: >
+    gpg --dearmor --yes -o "{{ rabbitmq_apt_keyring_path }}" /tmp/rabbitmq-team.asc
+  when:
+    - rabbitmq_apt_keyring_path is defined
+    - rabbitmq_apt_key_download is defined
+    - rabbitmq_apt_key_download.changed
+
 - name: Add Erlang repository
   ansible.builtin.deb822_repository:
     components: main
     name: erlang
-    signed_by: "{{ erlang_apt_gpg_url }}"
+    signed_by: "{{ rabbitmq_apt_keyring_path | default(erlang_apt_gpg_url) }}"
     suites: "{{ ansible_facts.distribution_release }}"
     uris: ["{{ erlang_apt_repository }}"]
     types: deb
@@ -24,7 +56,7 @@
   ansible.builtin.deb822_repository:
     components: main
     name: rabbitmq
-    signed_by: "{{ rabbitmq_apt_gpg_url }}"
+    signed_by: "{{ rabbitmq_apt_keyring_path | default(rabbitmq_apt_gpg_url) }}"
     suites: "{{ ansible_facts.distribution_release }}"
     uris: ["{{ rabbitmq_apt_repository }}"]
     types: deb
@@ -38,16 +70,16 @@
     group: root
     mode: 0644
 
-- name: Update apt cache.
+- name: Update apt cache
   apt: update_cache=true
   when: ansible_facts.os_family == 'Debian'
 
-- name: Ensure erlang is installed.
+- name: Ensure erlang is installed
   ansible.builtin.package:
     name: erlang
     state: present
 
-- name: Ensure RabbitMQ is installed.
+- name: Ensure RabbitMQ is installed
   ansible.builtin.apt:
     name: rabbitmq-server={{ rabbitmq_version }}-1
     state: present

--- a/templates/apt_pin.j2
+++ b/templates/apt_pin.j2
@@ -6,3 +6,4 @@ Pin: version 1:26.2.5.9-1
 Pin: version 1:25.3.2.18-1
 {% endif %}
 Pin-Priority: 1001
+Pin: origin RabbitMQ


### PR DESCRIPTION
The old Cloudsmith-backed ppa1/ppa2 hosts [went dark](https://www.rabbitmq.com/blog/2025/07/16/debian-apt-repositories-are-moving) after Nov 1, 2025, so Debian/Ubuntu installs now fail during apt cache refresh. Default repo URLs are moved to the new RabbitMQ-managed deb1 mirror, with the Team RabbitMQ signing key installed into `/usr/share/keyrings`.

Legacy key URL variables remain for compatibility and are used only if the keyring path is unset. Debian tasks now install curl/gnupg/apt-transport-https, fetch and dearmor the key, add deb822 repos with the new keyring, and pin Origin RabbitMQ.

@geerlingguy, let me know if the solution is sound. I'm happy to make further changes if needed.

Fixes https://github.com/geerlingguy/ansible-role-rabbitmq/issues/30.