### PR TITLE
Fix Debian deb822 repository dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: RabbitMQ installation for Linux.
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
-  min_ansible_version: 2.10
+  min_ansible_version: 2.15
   platforms:
     - name: Fedora
       versions:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,10 +10,5 @@
         cache_valid_time: 600
       when: ansible_facts.os_family == 'Debian'
 
-    - name: Add python3-debian dependency.
-      apt:
-        name: python3-debian
-      when: ansible_facts.os_family == 'Debian'
-
   roles:
     - role: geerlingguy.rabbitmq

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -11,6 +11,11 @@
     - ansible_facts.distribution == 'Ubuntu'
     - ansible_facts.distribution_major_version | int >= 18
 
+- name: Ensure deb822 repository dependency is installed.
+  ansible.builtin.apt:
+    name: python3-debian
+    state: present
+
 - name: Add Erlang repository
   ansible.builtin.deb822_repository:
     components: main


### PR DESCRIPTION
## Summary
- Install python3-debian before using ansible.builtin.deb822_repository on Debian-family hosts.
- Raise min_ansible_version to 2.15, since deb822_repository is not available in older ansible-core releases.
- Remove the Molecule-only python3-debian pre-task so the role itself owns the dependency.

## Validation
- Before this change, a clean Ubuntu 22.04 run with ansible-core 2.14 failed with: couldn't resolve module/action 'ansible.builtin.deb822_repository'.
- Before this change, a clean Ubuntu 22.04 run with ansible-core 2.15 failed with: No module named 'debian'.
- After this change, the same Ubuntu 22.04 + ansible-core 2.15 run completed successfully: ok=11, failed=0.